### PR TITLE
Policy and system requirement update for Vault 1.12

### DIFF
--- a/products/vault_selinux/vault.te
+++ b/products/vault_selinux/vault.te
@@ -46,6 +46,7 @@ require {
 	type vault_sys_content_t;
 	type vault_log_t;
 	type kernel_t; # Needed for /dev/log
+        type init_t; # Needed for systemD to read vault.env
 	type unreserved_port_t;
 	class netlink_route_socket { bind create getattr nlmsg_read read write };
 	class tcp_socket { accept bind connect create getattr getopt listen setopt read write };
@@ -61,7 +62,7 @@ allow vault_t self:fifo_file rw_fifo_file_perms;
 allow vault_t self:unix_stream_socket create_stream_socket_perms;
 # and network sockets too
 allow vault_t self:netlink_route_socket { bind create getattr nlmsg_read };
-allow vault_t self:unix_dgram_socket { bind create getattr setopt connect sendto };
+allow vault_t self:unix_dgram_socket { bind create getattr setopt connect sendto write };
 allow vault_t self:tcp_socket { accept bind create getattr listen setopt read write };
 allow vault_t unreserved_port_t:tcp_socket name_connect;
 # Allow to write to /dev/log
@@ -138,6 +139,8 @@ corecmd_exec_bin(vault_t)
 ###  Allows caller to read system state information in /proc.
 kernel_read_system_state(vault_t)
 
+# Need to allow systemD access to read vault.env
+allow init_t vault_conf_t:file { read open };
 
 # Need to access data files
 allow vault_t vault_sys_content_t:dir { add_name create getattr open read write search };

--- a/products/vault_selinux/vault_selinux.spec
+++ b/products/vault_selinux/vault_selinux.spec
@@ -31,8 +31,8 @@ BuildArch: noarch
 %endif
 
 %if 0%{?el8}
-Requires: policycoreutils, libselinux-utils
-Requires(post): selinux-policy-targeted, policycoreutils
+Requires: policycoreutils, libselinux-utils,policycoreutils-python-utils
+Requires(post): selinux-policy-targeted, policycoreutils, policycoreutils-python-utils
 Requires(postun): policycoreutils
 BuildArch: noarch
 %endif
@@ -102,6 +102,9 @@ exit 0
 
 
 %changelog
+* Mon Nov 14 2022 Jan Prinsloo <jan.prinsloo@hashicorp.com> 0.1.6-1
+- Added policycoreutils-python-utils requirement for Centos8/RHEL8
+
 * Wed Jan 6 2021 Christian Frichot <cfrichot@hashicorp.com> 0.1.5-1
 - Simplified local-package Makefile target
 


### PR DESCRIPTION
The original systemD unit file shipped with the Vault 1.6 rpm has changed in later versions of the Vault rpm and now has the following added flags:
```
Type=notify
EnvironmentFile=/etc/vault.d/vault.env
```
These require additional permissions in order for Vault to report back to systemD as well as allow systemD to read the ENV variables placed in `/etc/vault.d/vault.env`

The rpm build containing the policies relies on `semanage` as it's called in the post-install script. On RHEL8 `semanage` is provided by `policycoreutils-python-utils`, so this has been added.