### PR TITLE
Some fixes (SystemD service and vault as proxy)

### DIFF
--- a/products/vault_selinux/vault.te
+++ b/products/vault_selinux/vault.te
@@ -42,6 +42,7 @@ corenet_port(vault_cluster_port_t)
 
 require {
 	type vault_t;
+	type init_t;
 	type vault_conf_t;
 	type vault_sys_content_t;
 	type vault_log_t;
@@ -50,8 +51,8 @@ require {
 	class netlink_route_socket { bind create getattr nlmsg_read read write };
 	class tcp_socket { accept bind connect create getattr getopt listen setopt read write };
 	class unix_dgram_socket { bind create getattr setopt connect sendto };
-	class file { create getattr lock map open read write };
-	class dir { add_name create getattr open read write search };
+	class file { create getattr lock map open read write unlink rename };
+	class dir { add_name create getattr open read write search remove_name };
 }
 
 # read-write file permissions on anonymous pipes
@@ -138,10 +139,12 @@ corecmd_exec_bin(vault_t)
 ###  Allows caller to read system state information in /proc.
 kernel_read_system_state(vault_t)
 
+# Need to allow systemD access to read vault.env
+allow init_t vault_conf_t:file { read open };
 
 # Need to access data files
-allow vault_t vault_sys_content_t:dir { add_name create getattr open read write search };
-allow vault_t vault_sys_content_t:file { create getattr lock map open read write };
+allow vault_t vault_sys_content_t:dir { add_name create getattr open read write search remove_name };
+allow vault_t vault_sys_content_t:file { create getattr lock map open read write unlink rename };
 
 # Need to access log files
 allow vault_t vault_log_t:dir { getattr search write add_name };
@@ -149,6 +152,7 @@ allow vault_t vault_log_t:file { create append open setattr };
 
 # Needs this for logging
 logging_create_devlog_dev(vault_t)
+logging_send_syslog_msg(vault_t)
 
 ## <desc>
 ## <p>


### PR DESCRIPTION
Dear maintainer,

I was trying to enable Selinux in a simple case: A little systemd service for a vault proxy.

After some tests I ran into somes issues this PR tries to solve:
- The `EnvironmentFile=` directive can't read the environment file `/etc/vault.d/vault.env`, we need to allow this (totally inspired by @kwagga https://github.com/hashicorp/vault-selinux-policies/pull/10)
- There is nowhere we can store the token generated by Vault proxy with the current SeLinux policy.  I've assumed we'de like to store it with the rest of the data in `/opt/vault` and modified `vault_sys_content_t` accordingly.
- The service is configured to be `Type=notify`, which mean it needs to access `/run/systemd/notify`. It also tries to access `/run/systemd/journal/socket` for some reasons. I think, instead of  re-inventing the wheel I just added the `logging_send_syslog_msg(vault_t)`.

Hope I could help improving this project.
Regards